### PR TITLE
Add context funcs, use interface rather than specifying *sql.DB

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,6 +1,7 @@
 package nap
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"strings"
@@ -59,11 +60,26 @@ func (db *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
 	return db.pdbs[0].Exec(query, args...)
 }
 
+// ExecContext executes a query without returning any rows.
+// The args are for any placeholder parameters in the query.
+// Exec uses the master as the underlying physical db.
+func (db *DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return db.pdbs[0].ExecContext(ctx, query, args...)
+}
+
 // Ping verifies if a connection to each physical database is still alive,
 // establishing a connection if necessary.
 func (db *DB) Ping() error {
 	return scatter(len(db.pdbs), func(i int) error {
 		return db.pdbs[i].Ping()
+	})
+}
+
+// PingContext verifies if a connection to each physical database is still
+// alive, establishing a connection if necessary.
+func (db *DB) PingContext(ctx context.Context) error {
+	return scatter(len(db.pdbs), func(i int) error {
+		return db.pdbs[i].PingContext(ctx)
 	})
 }
 
@@ -84,11 +100,38 @@ func (db *DB) Prepare(query string) (Stmt, error) {
 	return &stmt{db: db, stmts: stmts}, nil
 }
 
+// PrepareContext creates a prepared statement for later queries or executions
+// on each physical database, concurrently.
+//
+// The provided context is used for the preparation of the statement, not for
+// the execution of the statement.
+func (db *DB) PrepareContext(ctx context.Context, query string) (Stmt, error) {
+	stmts := make([]*sql.Stmt, len(db.pdbs))
+
+	err := scatter(len(db.pdbs), func(i int) (err error) {
+		stmts[i], err = db.pdbs[i].PrepareContext(ctx, query)
+		return err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &stmt{db: db, stmts: stmts}, nil
+}
+
 // Query executes a query that returns rows, typically a SELECT.
 // The args are for any placeholder parameters in the query.
 // Query uses a slave as the physical db.
 func (db *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	return db.pdbs[db.slave(len(db.pdbs))].Query(query, args...)
+	return db.Slave().Query(query, args...)
+}
+
+// QueryContext executes a query that returns rows, typically a SELECT.
+// The args are for any placeholder parameters in the query.
+// QueryContext uses a slave as the physical db.
+func (db *DB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return db.Slave().QueryContext(ctx, query, args...)
 }
 
 // QueryRow executes a query that is expected to return at most one row.
@@ -96,7 +139,15 @@ func (db *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
 // Errors are deferred until Row's Scan method is called.
 // QueryRow uses a slave as the physical db.
 func (db *DB) QueryRow(query string, args ...interface{}) *sql.Row {
-	return db.pdbs[db.slave(len(db.pdbs))].QueryRow(query, args...)
+	return db.Slave().QueryRow(query, args...)
+}
+
+// QueryRowContext executes a query that is expected to return at most one row.
+// QueryRowContext always return a non-nil value.
+// Errors are deferred until Row's Scan method is called.
+// QueryRowContext uses a slave as the physical db.
+func (db *DB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return db.Slave().QueryRowContext(ctx, query, args...)
 }
 
 // SetMaxIdleConns sets the maximum number of connections in the idle

--- a/db.go
+++ b/db.go
@@ -13,6 +13,7 @@ type SQLDB interface {
 	Close() error
 	Driver() driver.Driver
 	Begin() (*sql.Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	Ping() error
@@ -70,6 +71,12 @@ func (db *DB) Driver() driver.Driver {
 // Begin starts a transaction on the master. The isolation level is dependent on the driver.
 func (db *DB) Begin() (*sql.Tx, error) {
 	return db.Pdbs[0].Begin()
+}
+
+// Begin starts a transaction with the provided context on the master.
+// The isolation level is dependent on the driver.
+func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return db.Pdbs[0].BeginTx(ctx, opts)
 }
 
 // Exec executes a query without returning any rows.

--- a/db.go
+++ b/db.go
@@ -9,12 +9,31 @@ import (
 	"time"
 )
 
+type SQLDB interface {
+	Close() error
+	Driver() driver.Driver
+	Begin() (*sql.Tx, error)
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	Ping() error
+	PingContext(ctx context.Context) error
+	Prepare(query string) (*sql.Stmt, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	SetConnMaxLifetime(d time.Duration)
+	SetMaxIdleConns(n int)
+	SetMaxOpenConns(n int)
+}
+
 // DB is a logical database with multiple underlying physical databases
 // forming a single master multiple slaves topology.
 // Reads and writes are automatically directed to the correct physical db.
 type DB struct {
-	pdbs  []*sql.DB // Physical databases
-	count uint64    // Monotonically incrementing counter on each query
+	Pdbs  []SQLDB // Physical databases
+	count uint64  // Monotonically incrementing counter on each query
 }
 
 // Open concurrently opens each underlying physical db.
@@ -22,10 +41,10 @@ type DB struct {
 // one being used as the master and the rest as slaves.
 func Open(driverName, dataSourceNames string) (*DB, error) {
 	conns := strings.Split(dataSourceNames, ";")
-	db := &DB{pdbs: make([]*sql.DB, len(conns))}
+	db := &DB{Pdbs: make([]SQLDB, len(conns))}
 
-	err := scatter(len(db.pdbs), func(i int) (err error) {
-		db.pdbs[i], err = sql.Open(driverName, conns[i])
+	err := scatter(len(db.Pdbs), func(i int) (err error) {
+		db.Pdbs[i], err = sql.Open(driverName, conns[i])
 		return err
 	})
 
@@ -38,58 +57,58 @@ func Open(driverName, dataSourceNames string) (*DB, error) {
 
 // Close closes all physical databases concurrently, releasing any open resources.
 func (db *DB) Close() error {
-	return scatter(len(db.pdbs), func(i int) error {
-		return db.pdbs[i].Close()
+	return scatter(len(db.Pdbs), func(i int) error {
+		return db.Pdbs[i].Close()
 	})
 }
 
 // Driver returns the physical database's underlying driver.
 func (db *DB) Driver() driver.Driver {
-	return db.pdbs[0].Driver()
+	return db.Pdbs[0].Driver()
 }
 
 // Begin starts a transaction on the master. The isolation level is dependent on the driver.
 func (db *DB) Begin() (*sql.Tx, error) {
-	return db.pdbs[0].Begin()
+	return db.Pdbs[0].Begin()
 }
 
 // Exec executes a query without returning any rows.
 // The args are for any placeholder parameters in the query.
 // Exec uses the master as the underlying physical db.
 func (db *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
-	return db.pdbs[0].Exec(query, args...)
+	return db.Pdbs[0].Exec(query, args...)
 }
 
 // ExecContext executes a query without returning any rows.
 // The args are for any placeholder parameters in the query.
 // Exec uses the master as the underlying physical db.
 func (db *DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	return db.pdbs[0].ExecContext(ctx, query, args...)
+	return db.Pdbs[0].ExecContext(ctx, query, args...)
 }
 
 // Ping verifies if a connection to each physical database is still alive,
 // establishing a connection if necessary.
 func (db *DB) Ping() error {
-	return scatter(len(db.pdbs), func(i int) error {
-		return db.pdbs[i].Ping()
+	return scatter(len(db.Pdbs), func(i int) error {
+		return db.Pdbs[i].Ping()
 	})
 }
 
 // PingContext verifies if a connection to each physical database is still
 // alive, establishing a connection if necessary.
 func (db *DB) PingContext(ctx context.Context) error {
-	return scatter(len(db.pdbs), func(i int) error {
-		return db.pdbs[i].PingContext(ctx)
+	return scatter(len(db.Pdbs), func(i int) error {
+		return db.Pdbs[i].PingContext(ctx)
 	})
 }
 
 // Prepare creates a prepared statement for later queries or executions
 // on each physical database, concurrently.
 func (db *DB) Prepare(query string) (Stmt, error) {
-	stmts := make([]*sql.Stmt, len(db.pdbs))
+	stmts := make([]*sql.Stmt, len(db.Pdbs))
 
-	err := scatter(len(db.pdbs), func(i int) (err error) {
-		stmts[i], err = db.pdbs[i].Prepare(query)
+	err := scatter(len(db.Pdbs), func(i int) (err error) {
+		stmts[i], err = db.Pdbs[i].Prepare(query)
 		return err
 	})
 
@@ -106,10 +125,10 @@ func (db *DB) Prepare(query string) (Stmt, error) {
 // The provided context is used for the preparation of the statement, not for
 // the execution of the statement.
 func (db *DB) PrepareContext(ctx context.Context, query string) (Stmt, error) {
-	stmts := make([]*sql.Stmt, len(db.pdbs))
+	stmts := make([]*sql.Stmt, len(db.Pdbs))
 
-	err := scatter(len(db.pdbs), func(i int) (err error) {
-		stmts[i], err = db.pdbs[i].PrepareContext(ctx, query)
+	err := scatter(len(db.Pdbs), func(i int) (err error) {
+		stmts[i], err = db.Pdbs[i].PrepareContext(ctx, query)
 		return err
 	})
 
@@ -156,8 +175,8 @@ func (db *DB) QueryRowContext(ctx context.Context, query string, args ...interfa
 // new MaxIdleConns will be reduced to match the MaxOpenConns limit
 // If n <= 0, no idle connections are retained.
 func (db *DB) SetMaxIdleConns(n int) {
-	for i := range db.pdbs {
-		db.pdbs[i].SetMaxIdleConns(n)
+	for i := range db.Pdbs {
+		db.Pdbs[i].SetMaxIdleConns(n)
 	}
 }
 
@@ -168,8 +187,8 @@ func (db *DB) SetMaxIdleConns(n int) {
 // the new MaxOpenConns limit. If n <= 0, then there is no limit on the number
 // of open connections. The default is 0 (unlimited).
 func (db *DB) SetMaxOpenConns(n int) {
-	for i := range db.pdbs {
-		db.pdbs[i].SetMaxOpenConns(n)
+	for i := range db.Pdbs {
+		db.Pdbs[i].SetMaxOpenConns(n)
 	}
 }
 
@@ -177,19 +196,19 @@ func (db *DB) SetMaxOpenConns(n int) {
 // Expired connections may be closed lazily before reuse.
 // If d <= 0, connections are reused forever.
 func (db *DB) SetConnMaxLifetime(d time.Duration) {
-	for i := range db.pdbs {
-		db.pdbs[i].SetConnMaxLifetime(d)
+	for i := range db.Pdbs {
+		db.Pdbs[i].SetConnMaxLifetime(d)
 	}
 }
 
 // Slave returns one of the physical databases which is a slave
-func (db *DB) Slave() *sql.DB {
-	return db.pdbs[db.slave(len(db.pdbs))]
+func (db *DB) Slave() SQLDB {
+	return db.Pdbs[db.slave(len(db.Pdbs))]
 }
 
 // Master returns the master physical database
-func (db *DB) Master() *sql.DB {
-	return db.pdbs[0]
+func (db *DB) Master() SQLDB {
+	return db.Pdbs[0]
 }
 
 func (db *DB) slave(n int) int {

--- a/db_test.go
+++ b/db_test.go
@@ -19,7 +19,7 @@ func TestOpen(t *testing.T) {
 		t.Error(err)
 	}
 
-	if want, got := 3, len(db.pdbs); want != got {
+	if want, got := 3, len(db.Pdbs); want != got {
 		t.Errorf("Unexpected number of physical dbs. Got: %d, Want: %d", got, want)
 	}
 }

--- a/stmt.go
+++ b/stmt.go
@@ -37,7 +37,7 @@ func (s *stmt) Exec(args ...interface{}) (sql.Result, error) {
 // arguments and returns the query results as a *sql.Rows.
 // Query uses a slave as the underlying physical db.
 func (s *stmt) Query(args ...interface{}) (*sql.Rows, error) {
-	return s.stmts[s.db.slave(len(s.db.pdbs))].Query(args...)
+	return s.stmts[s.db.slave(len(s.db.Pdbs))].Query(args...)
 }
 
 // QueryRow executes a prepared query statement with the given arguments.
@@ -47,5 +47,5 @@ func (s *stmt) Query(args ...interface{}) (*sql.Rows, error) {
 // Otherwise, the *sql.Row's Scan scans the first selected row and discards the rest.
 // QueryRow uses a slave as the underlying physical db.
 func (s *stmt) QueryRow(args ...interface{}) *sql.Row {
-	return s.stmts[s.db.slave(len(s.db.pdbs))].QueryRow(args...)
+	return s.stmts[s.db.slave(len(s.db.Pdbs))].QueryRow(args...)
 }


### PR DESCRIPTION
Making Pdbs public allows us to easily wrap the underlying instances with other pkgs. 