### PR TITLE
Add database picker master/slave when QueryRow is called

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1,6 +1,8 @@
 package nap
 
 import (
+	"database/sql"
+	"strings"
 	"testing"
 	"testing/quick"
 
@@ -57,5 +59,45 @@ func TestSlave(t *testing.T) {
 
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestQueryRow(t *testing.T) {
+	// https://www.sqlite.org/inmemorydb.html
+	db, err := Open("sqlite3", ":memory:;:memory:;:memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if err = db.Ping(); err != nil {
+		t.Error(err)
+	}
+
+	master := false
+
+	db.SetQueryRowDB(func(query string, args ...interface{}) *sql.DB {
+		if len(query) > 12 && strings.ToLower(query)[0:12] == "insert into " {
+			master = true
+			return db.Master()
+		}
+		master = false
+		return db.Slave()
+	})
+
+	res := db.QueryRow("insert into t1(c1,c2) values(1,1);", nil)
+	if res == nil {
+		t.Errorf("func QueryRow has no results")
+	}
+	if !master {
+		t.Errorf("query row expected to use master database")
+	}
+
+	res = db.QueryRow("select * from t1", nil)
+	if res == nil {
+		t.Errorf("func QueryRow has no results")
+	}
+	if master {
+		t.Errorf("query row expected to use slave database")
 	}
 }


### PR DESCRIPTION
This is useful when using postgres database, github.com/lib/pq driver does not implement LastInsertId() func so there is no other way to get auto-incremental id by running Exec, which means we have to use QueryRow to get that id, for this reason we need a conditional database picker by looking at some args such as query or args part of QueryRow func.